### PR TITLE
Adds support for publishing to BinTray.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,62 +1,41 @@
-buildscript {
-    ext.kotlin_version = '0.1-SNAPSHOT'
-    ext.dokka_version = '0.9.7'
-    repositories {
-        mavenCentral()
-        jcenter()
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
-    }
+plugins {
+    id "com.zoltu.kotlin" version "1.0.3"
+    id "com.zoltu.git-versioning" version "2.0.20"
+    id "com.jfrog.bintray" version "1.7"
+    id "maven-publish"
 }
 
-if (hasProperty("teamcity") && kotlin_version != '0.1-SNAPSHOT') {
-    version = teamcity["build.number"]
-} else
-    version = "0.1-SNAPSHOT"
+def kotlin_version = "1.0.3"
 
-apply plugin: 'kotlin'
-// apply plugin: 'org.jetbrains.dokka'
+apply from: 'gradle/package.gradle'
+apply from: 'gradle/publish.gradle'
 
 repositories {
+    jcenter()
     mavenCentral()
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
-    }
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
-    }
-}
-
-compileKotlin {
-    // kotlinOptions.annotations = file('annotations/Gradle_io.netty_netty-all_4.0.31.Final')
 }
 
 dependencies {
-    compile "io.netty:netty-all:4.1.0.CR6",
-            "commons-codec:commons-codec:1.9",
-            "commons-logging:commons-logging:1.1.1",
-            "com.netflix.rxjava:rxjava-core:0.20.0-RC4",
-            "org.slf4j:slf4j-api:1.7.5",
-            "org.slf4j:slf4j-simple:1.7.5",
-            "joda-time:joda-time:2.3",
-            "com.fasterxml.jackson.core:jackson-core:2.8.1",
-            "com.fasterxml.jackson.core:jackson-databind:2.8.1",
-            "com.fasterxml.jackson.core:jackson-annotations:2.8.1",
-            "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.8.1",
-            "com.fasterxml.jackson.module:jackson-module-kotlin:2.8.1",
-            "com.fasterxml.woodstox:woodstox-core:5.0.1",
-            "org.yaml:snakeyaml:1.17",
-            // Used for HTTP2 support.
-            "org.mortbay.jetty.alpn:alpn-boot:8.1.8.v20160420"
-
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+
+    compile "io.netty:netty-all:4.1.0.CR6"
+    compile "commons-codec:commons-codec:1.9"
+    compile "commons-logging:commons-logging:1.1.1"
+    compile "com.netflix.rxjava:rxjava-core:0.20.0-RC4"
+    compile "org.slf4j:slf4j-api:1.7.5"
+    compile "org.slf4j:slf4j-simple:1.7.5"
+    compile "joda-time:joda-time:2.3"
+    compile "com.fasterxml.jackson.core:jackson-core:2.8.1"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.8.1"
+    compile "com.fasterxml.jackson.core:jackson-annotations:2.8.1"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.8.1"
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.8.1"
+    compile "com.fasterxml.woodstox:woodstox-core:5.0.1"
+    compile "org.yaml:snakeyaml:1.17"
+    // Used for HTTP2 support.
+    compile "org.mortbay.jetty.alpn:alpn-boot:8.1.8.v20160420"
 
     testCompile "junit:junit:4.9"
     testCompile "org.mockito:mockito-all:1.9.5"
@@ -64,84 +43,11 @@ dependencies {
     testCompile 'com.squareup.okhttp3:okhttp:3.2.0'
 }
 
-
 test {
-
     // set heap size for the test JVM(s)
     minHeapSize = "128m"
     maxHeapSize = "512m"
 
     // set JVM arguments for the test JVM(s)
     jvmArgs '-XX:MaxPermSize=256m'
-}
-
-sourceSets {
-    main {
-        kotlin {
-            srcDir "src/main/kotlin"
-        }
-    }
-
-    test {
-        kotlin {
-            srcDir "test/main/kotlin"
-        }
-    }
-    main.java.srcDirs += 'src/main/kotlin'
-}
-apply plugin: 'maven'
-apply plugin: 'maven-publish'
-
-task sourceJar(type: Jar) {
-    from sourceSets.main.allSource
-}
-
-artifacts {
-    archives sourceJar
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId = "org.wasabi"
-            artifactId = "wasabi"
-            version = "${version}"
-
-            from components.java
-
-            artifact sourceJar {
-                classifier "sources"
-            }
-        }
-    }
-
-
-    repositories {
-        maven {
-            url "http://repository.jetbrains.com/wasabi"
-            if (rootProject.hasProperty("deploy_username") && rootProject.hasProperty("deploy_password")) {
-                credentials {
-                    username "${rootProject.deploy_username}"
-                    password "${rootProject.deploy_password}"
-                }
-            }
-        }
-    }
-
-
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
-
-    doLast() {
-        def gradleOpts = "-XX:MaxPermSize=300m -Xmx1024m"
-        def gradlew_sh = file("gradlew")
-        def gradlew_bat = file("gradlew.bat")
-        gradlew_sh.text = gradlew_sh.text.replace("DEFAULT_JVM_OPTS=",
-                "GRADLE_OPTS=\"$gradleOpts \$GRADLE_OPTS\"\nDEFAULT_JVM_OPTS=")
-        gradlew_bat.text = gradlew_bat.text.replace("set DEFAULT_JVM_OPTS=",
-                "set GRADLE_OPTS=$gradleOpts %GRADLE_OPTS%\nset DEFAULT_JVM_OPTS=")
-
-    }
 }

--- a/gradle/package.gradle
+++ b/gradle/package.gradle
@@ -1,0 +1,16 @@
+group 'org.wasabifx'
+
+jar {
+    manifest {
+        attributes(
+                "Implementation-Title": "wasabi",
+                "Implementation-Vendor": "wasabifx"
+        )
+    }
+}
+
+task sourceJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier "sources"
+    setManifest(jar.getManifest())
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,24 @@
+artifacts {
+    archives sourceJar
+}
+
+publishing {
+    publications {
+        MyMavenPublication(MavenPublication) {
+            from components.java
+            artifact sourceJar
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    publications = ['MyMavenPublication']
+    publish = true
+    pkg {
+        userOrg = 'wasabifx'
+        repo = 'wasabifx'
+        name = 'wasabi'
+    }
+}


### PR DESCRIPTION
In the process of adding BinTray support, I also cleaned up the gradle script and changed the versioning system.  This is a fairly opinionated PR and I don't mind undoing some of the opinions but I wanted to start from a place that *I* felt was good and then take things out as desired by the maintainers rather than assuming everything was the way it was on purpose (in my experience, gradle build files tend to "just happen" and are often unintentional).

Versioning: This uses an [auto versioning plugin](https://github.com/Zoltu/Gradle.Plugin.Versioning) that will get the `major.minor` version from a git tag and then add the commit count as the patch version.  This results in a version number that always increases and correlates with a particular commit in git (assuming you don't rewrite history of your master branch).

Publishing: `./gradlew bintrayUpload` will publish to bintray.  IMO, this should only be executed by the build server on commits (or merges) to `master`.  It requires two environment variables `BINTRAY_USER` and `BINTRAY_KEY` to actually do the upload, which presumably only the build server would have.  This, combined with the automatic versioning system, results in a CI/CD system where every commit to master will publish a unique version to BinTray.  Major/minor version bumps require a git tag like `v1.0`.

Gradle: I have switched to using the new gradle `plugin` syntax and I have also split the main `build.gradle` up into several separate files.  I have removed the snapshot repository as well so all dependencies will now come from release versions, or at least only versions published to `mavenCentral` or `jCenter`.