### PR TITLE
Adds explicit artifact ID.

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -6,6 +6,7 @@ publishing {
     publications {
         MyMavenPublication(MavenPublication) {
             from components.java
+            artifactId 'wasabi'
             artifact sourceJar
         }
     }


### PR DESCRIPTION
Gradle will use the containing folder name for the artifact ID if one isn't explicitly supplied.  On the build server, this often won't be the name of the git repository (`wasabi`) which is what we want.