### PR TITLE
Set content length to payload size if not set

### DIFF
--- a/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpRequestHandler.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpRequestHandler.kt
@@ -178,10 +178,14 @@ class HttpRequestHandler(private val appServer: AppServer): SimpleChannelInbound
             }
         } else if (response.negotiatedMediaType == "application/octet-stream") {
             httpResponse = DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus(response.statusCode, response.statusDescription));
+            val responseBytes = response.sendBuffer as ByteArray
+            if (response.contentLength <= 0) {
+                response.contentLength = responseBytes.size
+            }
             response.setHeaders()
             addResponseHeaders(httpResponse, response)
             ctx.write(httpResponse)
-            ctx.write(Unpooled.wrappedBuffer(response.sendBuffer as ByteArray))
+            ctx.write(Unpooled.wrappedBuffer(responseBytes))
             val lastContentFuture = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
 
             if (request!!.connection.compareTo("close", ignoreCase = true) == 0) {


### PR DESCRIPTION
If someone has already set the content length, let it ride. Otherwise, set it to the number of bytes in the payload since that is probably what the user expects to happen.

This is a redo of #67 