### PR TITLE
HTTP Client for writing tests

### DIFF
--- a/test/main/kotlin/org/wasabifx/wasabi/test/BinaryContentSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/BinaryContentSpecs.kt
@@ -13,6 +13,6 @@ class BinaryContentSpecs: TestServerContext() {
                 })
 
         val response = get("http://localhost:${TestServer.definedPort}/binary/thing")
-        assertEquals(8, response.body.length)
+        assertEquals(8, response.body?.length)
     }
 }

--- a/test/main/kotlin/org/wasabifx/wasabi/test/BodyParametersSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/BodyParametersSpecs.kt
@@ -30,11 +30,11 @@ class BodyParametersSpecs : TestServerContext() {
 
         val response = post("http://localhost:${TestServer.definedPort}/params", hashMapOf(), urlParameters)
 
-        assert(response.body.contains("1"))
+        assert(response.body?.contains("1") ?: false)
 
         val response2 = post("http://localhost:${TestServer.definedPort}/params", hashMapOf(), urlParameters2)
 
-        assert(response2.body.contains("1"))
+        assert(response2.body?.contains("1") ?: false)
 
     }
 

--- a/test/main/kotlin/org/wasabifx/wasabi/test/ContentNegotiationSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/ContentNegotiationSpecs.kt
@@ -168,7 +168,7 @@ class ContentNegotiationSpecs : TestServerContext() {
         val actualContentType = response.headers.filter { it.name == "Content-Type" }
                 .first().value.split(";").first()
         assertEquals(expectedContentType, actualContentType)
-        assertEquals("{\"cause\":null", response.body.substring(0, 13))
+        assertEquals("{\"cause\":null", response.body?.substring(0, 13))
     }
 
     @spec fun returning_content_as_string_with_custom_content_type_must_work() {

--- a/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
@@ -136,6 +136,6 @@ fun postForm(url: String, headers: HashMap<String, String>, fields: ArrayList<Ba
     return makeRequest(headers, httpPost)
 }
 
-data class HttpClientResponse(val headers: Array<Header>, val body: String, val statusCode: Int, val statusDescription: String)
+data class HttpClientResponse(val headers: Array<Header>, val body: String?, val statusCode: Int, val statusDescription: String)
 
 

--- a/test/main/kotlin/org/wasabifx/wasabi/test/StaticFileInterceptorSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/StaticFileInterceptorSpecs.kt
@@ -76,7 +76,7 @@ class StaticFileInterceptorSpecs: TestServerContext() {
 
         val response = get("http://localhost:${TestServer.definedPort}/file%20with%20spaces%20in%20filename.txt", hashMapOf())
 
-        assertEquals("lorem ipsum", response.body.trim())
+        assertEquals("lorem ipsum", response.body?.trim())
     }
 
     @spec fun requesting_an_file_outside_of_static_folder_should_raise_internal_server_error() {
@@ -85,6 +85,6 @@ class StaticFileInterceptorSpecs: TestServerContext() {
 
         val response = get("http://localhost:${TestServer.definedPort}/..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd", hashMapOf())
 
-        assertEquals("Internal Server Error", response.body.trim())
+        assertEquals("Internal Server Error", response.body?.trim())
     }
 }

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
@@ -38,9 +38,9 @@ class TestClient(val appServer: AppServer) {
             entity.isChunked = chunked
             httpRequest.setHeader("Content-Type", "application/x-www-form-urlencoded")
             httpRequest.entity = entity
+        } else {
+            throw Exception("Cannot send form with this HTTP method ($method).")
         }
-
-        // @TODO check GET case
 
         return executeRequest(headers, httpRequest)
     }
@@ -61,9 +61,9 @@ class TestClient(val appServer: AppServer) {
         if (httpRequest is HttpEntityEnclosingRequestBase) {
             httpRequest.setHeader("Content-Type", "application/json")
             httpRequest.entity = StringEntity(json)
+        } else {
+            throw Exception("Cannot send JSON with this HTTP method ($method).")
         }
-
-        // @TODO check GET case
 
         return executeRequest(headers, httpRequest)
     }
@@ -109,7 +109,7 @@ class TestClient(val appServer: AppServer) {
         request.setHeader("Connection", "Close")
 
         val response = httpClient.execute(request)!!
-        val body = EntityUtils.toString(response.entity)!!
+        val body = if (response.entity != null) { EntityUtils.toString(response.entity) } else { null }
         val responseHeaders = response.allHeaders!!
 
         return HttpClientResponse(responseHeaders, body,

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
@@ -1,0 +1,102 @@
+package org.wasabifx.wasabi.test
+
+import com.sun.javaws.exceptions.InvalidArgumentException
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.methods.*
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.BasicCookieStore
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.cookie.BasicClientCookie
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.util.EntityUtils
+import org.wasabifx.wasabi.app.AppServer
+import java.util.*
+
+class TestClient(val appServer: AppServer) {
+
+    companion object Methods {
+        val GET = "GET"
+        val POST = "POST"
+        val PUT = "PUT"
+        val DELETE = "DELETE"
+        val PATCH = "PATCH"
+        val HEAD = "HEAD"
+        val OPTIONS = "OPTIONS"
+        val TRACE = "TRACE"
+    }
+
+    fun makeSimpleRequest(url: String, method: String, headers: HashMap<String, String> = hashMapOf()): HttpClientResponse {
+        val httpRequest = getMethod(url, method)
+        return makeRequest(headers, httpRequest)
+    }
+
+    fun sendForm(url: String, method: String, fields: ArrayList<BasicNameValuePair>, headers: HashMap<String, String> = hashMapOf(), chunked: Boolean = false): HttpClientResponse {
+        val httpRequest = getMethod(url, method)
+
+        if (httpRequest is HttpEntityEnclosingRequestBase) {
+            val entity = UrlEncodedFormEntity(fields, "UTF-8")
+            entity.isChunked = chunked
+            httpRequest.setHeader("Content-Type", "application/x-www-form-urlencoded")
+            httpRequest.entity = entity
+        }
+
+        // @TODO check GET case
+
+        return makeRequest(headers, httpRequest)
+    }
+
+    fun sendJson(url: String, method: String, json: String, headers: HashMap<String, String> = hashMapOf()): HttpClientResponse {
+        val httpRequest = getMethod(url, method)
+
+        if (httpRequest is HttpEntityEnclosingRequestBase) {
+            httpRequest.setHeader("Content-Type", "application/json")
+            httpRequest.entity = StringEntity(json)
+        }
+
+        // @TODO check GET case
+
+        return makeRequest(headers, httpRequest)
+    }
+
+    private fun getMethod(url: String, method: String): HttpRequestBase {
+        val fullUrl = "http://localhost:" + appServer.configuration.port.toString() + url
+
+        return when (method) {
+            TestClient.GET -> { HttpGet(fullUrl) }
+            TestClient.POST -> { HttpPost(fullUrl) }
+            TestClient.PUT -> { HttpPut(fullUrl) }
+            TestClient.DELETE -> { HttpDelete(fullUrl) }
+            TestClient.PATCH -> { HttpPatch(fullUrl) }
+            TestClient.HEAD -> { HttpHead(fullUrl) }
+            TestClient.OPTIONS -> { HttpOptions(fullUrl) }
+            TestClient.TRACE -> { HttpTrace(fullUrl) } // is not supported by wasabi server
+            else  -> { throw Exception("Invalid method") }
+        }
+    }
+
+    private fun makeRequest(headers: HashMap<String, String>, request: HttpRequestBase, cookies: HashMap<String, String> = hashMapOf()): HttpClientResponse {
+
+        val cookieStore = BasicCookieStore()
+
+        for ((key, value) in cookies) {
+            val custom_cookie = BasicClientCookie(key, value)
+            custom_cookie.path = request.uri?.path
+            custom_cookie.domain = "localhost"
+            cookieStore.addCookie(custom_cookie)
+        }
+
+        val httpClient = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build()
+        for ((key, value) in headers) {
+            request.setHeader(key, value)
+        }
+        request.setHeader("Connection", "Close")
+
+        val response = httpClient.execute(request)!!
+        val body = EntityUtils.toString(response.entity)!!
+        val responseHeaders = response.allHeaders!!
+
+        return HttpClientResponse(responseHeaders, body,
+            response.statusLine?.statusCode!!,
+            response.statusLine?.reasonPhrase ?: "")
+    }
+}

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClient.kt
@@ -25,7 +25,7 @@ class TestClient(val appServer: AppServer) {
         val TRACE = "TRACE"
     }
 
-    fun makeSimpleRequest(url: String, method: String, headers: HashMap<String, String> = hashMapOf()): HttpClientResponse {
+    fun sendSimpleRequest(url: String, method: String, headers: HashMap<String, String> = hashMapOf()): HttpClientResponse {
         val httpRequest = getMethod(url, method)
         return makeRequest(headers, httpRequest)
     }

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
@@ -15,7 +15,7 @@ class TestClientSpecs : TestServerContext(){
 
         val client = TestClient(TestServer.appServer)
 
-        assertEquals("Correct", client.makeSimpleRequest("/testget", TestClient.GET).body)
+        assertEquals("Correct", client.sendSimpleRequest("/testget", TestClient.GET).body)
     }
 
     @Test fun test_multiple_get_requests() {
@@ -25,8 +25,8 @@ class TestClientSpecs : TestServerContext(){
 
         val client = TestClient(TestServer.appServer)
 
-        assertEquals("Correct", client.makeSimpleRequest("/testget", TestClient.GET).body)
-        assertEquals("Correct2", client.makeSimpleRequest("/testget2", TestClient.GET).body)
+        assertEquals("Correct", client.sendSimpleRequest("/testget", TestClient.GET).body)
+        assertEquals("Correct2", client.sendSimpleRequest("/testget2", TestClient.GET).body)
     }
 
     @Test fun test_json_post_put_patch_requests() {
@@ -73,8 +73,8 @@ class TestClientSpecs : TestServerContext(){
 
         val client = TestClient(TestServer.appServer)
 
-        assertEquals("delete method", client.makeSimpleRequest("/resource", TestClient.DELETE).body)
-        assertEquals("options method", client.makeSimpleRequest("/resource", TestClient.OPTIONS).body)
+        assertEquals("delete method", client.sendSimpleRequest("/resource", TestClient.DELETE).body)
+        assertEquals("options method", client.sendSimpleRequest("/resource", TestClient.OPTIONS).body)
     }
 
     // @TODO add methods which test additional headers in request.

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
@@ -29,7 +29,7 @@ class TestClientSpecs : TestServerContext(){
         assertEquals("Correct2", client.sendSimpleRequest("/testget2", TestClient.GET).body)
     }
 
-    @Test fun test_json_post_put_patch_requests() {
+    @Test fun test_json_post_put_patch_json_string_requests() {
         TestServer.reset()
         TestServer.appServer.post("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
         TestServer.appServer.put("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
@@ -42,7 +42,29 @@ class TestClientSpecs : TestServerContext(){
         assertEquals("patchtest", client.sendJson("/json", TestClient.PATCH, """{"test":"patchtest"}""").body)
     }
 
-    @Test fun test_form_post_put_patch_requests() {
+    @Test fun test_json_post_put_patch_json_hashmap_requests() {
+        TestServer.reset()
+        TestServer.appServer.post("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.put("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.patch("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("posttest", client.sendJson("/json", TestClient.POST, hashMapOf("test" to "posttest")).body)
+        assertEquals("puttest", client.sendJson("/json", TestClient.PUT, hashMapOf("test" to "puttest")).body)
+        assertEquals("patchtest", client.sendJson("/json", TestClient.PATCH, hashMapOf("test" to "patchtest")).body)
+    }
+
+    @Test fun test_json_post_json_multilevel_hashmap_request() {
+        TestServer.reset()
+        TestServer.appServer.post("/json", { response.send(request.bodyParams["test"] ?: "key not found", "application/json") })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("""{"another":"weeee"}""", client.sendJson("/json", TestClient.POST, hashMapOf("test" to hashMapOf("another" to "weeee"))).body)
+    }
+
+    @Test fun test_form_post_put_patch_arraylist_requests() {
         TestServer.reset()
         TestServer.appServer.post("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
         TestServer.appServer.put("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
@@ -62,6 +84,19 @@ class TestClientSpecs : TestServerContext(){
         assertEquals("posttest", client.sendForm("/form", TestClient.POST, postFormFields).body)
         assertEquals("puttest", client.sendForm("/form", TestClient.PUT, putFormFields).body)
         assertEquals("patchtest", client.sendForm("/form", TestClient.PATCH, patchFormFields).body)
+    }
+
+    @Test fun test_form_post_put_patch_hashmap_requests() {
+        TestServer.reset()
+        TestServer.appServer.post("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.put("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.patch("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("posttest", client.sendForm("/form", TestClient.POST, hashMapOf("test" to "posttest")).body)
+        assertEquals("puttest", client.sendForm("/form", TestClient.PUT, hashMapOf("test" to "puttest")).body)
+        assertEquals("patchtest", client.sendForm("/form", TestClient.PATCH, hashMapOf("test" to "patchtest")).body)
     }
 
     @Test fun test_delete_options_requests() {

--- a/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/TestClientSpecs.kt
@@ -1,0 +1,81 @@
+package org.wasabifx.wasabi.test
+
+import org.apache.http.message.BasicNameValuePair
+import org.junit.Test
+import java.util.*
+import kotlin.test.assertEquals
+
+class TestClientSpecs : TestServerContext(){
+
+    @Test fun test_get_request() {
+        TestServer.reset()
+        TestServer.appServer.get("/testget", {
+            response.send("Correct", "text/plain")
+        })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("Correct", client.makeSimpleRequest("/testget", TestClient.GET).body)
+    }
+
+    @Test fun test_multiple_get_requests() {
+        TestServer.reset()
+        TestServer.appServer.get("/testget", { response.send("Correct", "text/plain") })
+        TestServer.appServer.get("/testget2", { response.send("Correct2", "text/plain") })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("Correct", client.makeSimpleRequest("/testget", TestClient.GET).body)
+        assertEquals("Correct2", client.makeSimpleRequest("/testget2", TestClient.GET).body)
+    }
+
+    @Test fun test_json_post_put_patch_requests() {
+        TestServer.reset()
+        TestServer.appServer.post("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.put("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.patch("/json", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("posttest", client.sendJson("/json", TestClient.POST, """{"test":"posttest"}""").body)
+        assertEquals("puttest", client.sendJson("/json", TestClient.PUT, """{"test":"puttest"}""").body)
+        assertEquals("patchtest", client.sendJson("/json", TestClient.PATCH, """{"test":"patchtest"}""").body)
+    }
+
+    @Test fun test_form_post_put_patch_requests() {
+        TestServer.reset()
+        TestServer.appServer.post("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.put("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+        TestServer.appServer.patch("/form", { response.send(request.bodyParams["test"] ?: "key not found", "text/plain") })
+
+        val client = TestClient(TestServer.appServer)
+
+        val postFormFields = ArrayList<BasicNameValuePair>()
+        postFormFields.add(BasicNameValuePair("test", "posttest"))
+
+        val putFormFields = ArrayList<BasicNameValuePair>()
+        putFormFields.add(BasicNameValuePair("test", "puttest"))
+
+        val patchFormFields = ArrayList<BasicNameValuePair>()
+        patchFormFields.add(BasicNameValuePair("test", "patchtest"))
+
+        assertEquals("posttest", client.sendForm("/form", TestClient.POST, postFormFields).body)
+        assertEquals("puttest", client.sendForm("/form", TestClient.PUT, putFormFields).body)
+        assertEquals("patchtest", client.sendForm("/form", TestClient.PATCH, patchFormFields).body)
+    }
+
+    @Test fun test_delete_options_requests() {
+        TestServer.reset()
+        TestServer.appServer.delete("/resource", { response.send("delete method", "text/plain") })
+        TestServer.appServer.options("/resource", { response.send("options method", "text/plain") })
+        // @TODO add head method test. For some unknown reason currently it doesn't work.
+
+
+        val client = TestClient(TestServer.appServer)
+
+        assertEquals("delete method", client.makeSimpleRequest("/resource", TestClient.DELETE).body)
+        assertEquals("options method", client.makeSimpleRequest("/resource", TestClient.OPTIONS).body)
+    }
+
+    // @TODO add methods which test additional headers in request.
+}


### PR DESCRIPTION
This Client is intended to write easily understandable tests , smaller test files and to cover all testing needs (send json, send form, etc).

Keep in mind, that sending form currently supports only one level of key->value combinations. If there is a need to make more comples form submits, we would need to adjust it in some ways.