### PR TITLE
Cleanup in Response , HttpRequestHandler classes

### DIFF
--- a/src/main/kotlin/org/wasabifx/wasabi/interceptors/FavIconInterceptor.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/interceptors/FavIconInterceptor.kt
@@ -11,7 +11,7 @@ class FavIconInterceptor(val icon: String): Interceptor {
     override fun intercept(request: Request, response: Response): Boolean {
         if (request.method == HttpMethod.GET && request.uri.compareTo("/favicon.ico", ignoreCase = true) == 0) {
             val path = icon.trim('/')
-            response.setFileResponseHeaders(path, "image/x-icon")
+            response.sendFile(path, "image/x-icon")
             return false
         } else {
             return true

--- a/src/main/kotlin/org/wasabifx/wasabi/interceptors/FileBasedErrorInterceptor.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/interceptors/FileBasedErrorInterceptor.kt
@@ -13,7 +13,7 @@ class FileBasedErrorInterceptor(val folder: String, val fileExtensions: String =
         if (!file.exists()) {
             fileToServe = "${path}/$fallbackGenericFile"
         }
-        response.setFileResponseHeaders(fileToServe)
+        response.sendFile(fileToServe)
 
         return false
     }

--- a/src/main/kotlin/org/wasabifx/wasabi/interceptors/StaticFileInterceptor.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/interceptors/StaticFileInterceptor.kt
@@ -30,8 +30,8 @@ public class StaticFileInterceptor(val folder: String, val useDefaultFile: Boole
             }
 
             when {
-                file.exists() && file.isFile() -> response.setFileResponseHeaders(fullPath)
-                file.exists() && file.isDirectory() && useDefaultFile -> response.setFileResponseHeaders("${fullPath}/${defaultFile}")
+                file.exists() && file.isFile() -> response.sendFile(fullPath)
+                file.exists() && file.isDirectory() && useDefaultFile -> response.sendFile("${fullPath}/${defaultFile}")
                 else -> executeNext = true
             }
         } else {

--- a/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpRequestHandler.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpRequestHandler.kt
@@ -161,15 +161,7 @@ class HttpRequestHandler(private val appServer: AppServer): SimpleChannelInbound
 
         // @TODO move this charset stuff
         var responseCharset = ""
-        val responseContentAsStream : ChunkedInput<ByteBuf> = if (response.absolutePathToFileToStream != "") {
-            // because Response.setFileResponseHeaders assigns contentType property, not negotiatedMediaType, we need to
-            // assign it back because later code sets contentType property with value of negotiatedMediaType :D
-            // should be fixed with another PR where Response class will be refactored in a way that it will use one
-            // contentType property, not two (contentType + negotiatedContentType)
-            response.negotiatedMediaType = response.contentType
-            val fileStream = FileInputStream(response.absolutePathToFileToStream)
-            ChunkedNioFile(fileStream.channel, 8192)
-        } else if (response.negotiatedMediaType == "application/octet-stream") {
+        val responseContentAsStream : ChunkedInput<ByteBuf> = if (response.negotiatedMediaType == "application/octet-stream" || response.sendBuffer is ByteArray) {
             val responseBytes = response.sendBuffer as ByteArray
             response.contentLength = responseBytes.size.toLong()
             ChunkedStream(responseBytes.inputStream())

--- a/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
@@ -38,7 +38,12 @@ class Response() {
         location = url
     }
 
+    @Deprecated("Use sendFile() instead", ReplaceWith("sendFile(filename, contentType)"))
     fun setFileResponseHeaders(filename: String, contentType: String = "*/*") {
+        this.sendFile(filename, contentType)
+    }
+
+    fun sendFile(filename: String, contentType: String = "*/*") {
 
         val file = File(filename)
         if (file.exists() && !file.isDirectory) {

--- a/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
@@ -1,7 +1,6 @@
 package org.wasabifx.wasabi.protocol.http
 
 import io.netty.handler.codec.http.HttpMethod
-import io.netty.handler.codec.http.cookie.ServerCookieEncoder
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
@@ -22,8 +21,6 @@ class Response() {
     var statusCode: Int = 200
     var statusDescription: String = ""
     var allow: String = ""
-    var absolutePathToFileToStream: String = ""
-        private set
     var sendBuffer: Any? = null
         private set
     var overrideContentNegotiation: Boolean = false
@@ -45,7 +42,8 @@ class Response() {
 
         val file = File(filename)
         if (file.exists() && !file.isDirectory) {
-            this.absolutePathToFileToStream = file.getAbsolutePath()
+            sendBuffer = file.readBytes()
+
             val fileContentType : String?
             when (contentType) {
                 "*/*" -> when {
@@ -64,7 +62,7 @@ class Response() {
                     fileContentType = contentType
                 }
             }
-            this.contentType = fileContentType ?: "application/unknown"
+            this.negotiatedMediaType = fileContentType ?: "application/unknown"
             this.contentLength = file.length()
             this.lastModified = DateTime(file.lastModified())
 


### PR DESCRIPTION
setFileResponseHeaders method used absolutePathToFileToStream property to define which file must be read into response, and that reading file part was implemented in HttpRequestHandler class. I've moved "reading file" into setFileResponseHeaders method, which simplified writeResponse method. 

Also I've renamed  setFileResponseHeaders method into sendFile