### PR TITLE
made search similar path when registration a new route to avoid conflicts

### DIFF
--- a/src/main/kotlin/org/wasabifx/wasabi/app/AppServer.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/app/AppServer.kt
@@ -1,6 +1,5 @@
 package org.wasabifx.wasabi.app
 
-import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.HttpMethod
 import org.slf4j.LoggerFactory
 import org.wasabifx.wasabi.deserializers.Deserializer
@@ -27,7 +26,7 @@ open class AppServer(val configuration: AppConfiguration = AppConfiguration()) {
     private val httpServer: HttpServer
     private var running = false
 
-    val routes: ArrayList<Route> = ArrayList<Route>()
+    val routes: MutableSet<Route> = mutableSetOf()
     val channels: ArrayList<Channel> = ArrayList<Channel>()
     val exceptionHandlers: MutableSet<RouteException> = mutableSetOf()
     val interceptors : ArrayList<InterceptorEntry>  = ArrayList<InterceptorEntry>()
@@ -40,9 +39,9 @@ open class AppServer(val configuration: AppConfiguration = AppConfiguration()) {
     }
 
     private fun addRoute(method: HttpMethod, path: String, vararg handler: RouteHandler.() -> Unit) {
-        val existingRoute = routes.filter { it.path == path && it.method == method }
-        if (existingRoute.count() >= 1) {
-            throw RouteAlreadyExistsException(existingRoute.firstOrNull()!!)
+        val existingRoute = routes.findSimilar(method, path)
+        if (existingRoute != null) {
+            throw RouteAlreadyExistsException(existingRoute)
         }
         routes.add(Route(path, method, HashMap<String, String>(), *handler))
     }

--- a/src/main/kotlin/org/wasabifx/wasabi/interceptors/AutoOptionsInterceptor.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/interceptors/AutoOptionsInterceptor.kt
@@ -1,15 +1,14 @@
 package org.wasabifx.wasabi.interceptors
 
+import io.netty.handler.codec.http.HttpMethod
+import org.wasabifx.wasabi.app.AppServer
 import org.wasabifx.wasabi.protocol.http.Request
 import org.wasabifx.wasabi.protocol.http.Response
-import org.wasabifx.wasabi.app.AppServer
-import io.netty.handler.codec.http.HttpMethod
-import java.util.ArrayList
-import org.wasabifx.wasabi.routing.Route
 import org.wasabifx.wasabi.protocol.http.StatusCodes
 import org.wasabifx.wasabi.routing.PatternAndVerbMatchingRouteLocator
+import org.wasabifx.wasabi.routing.Route
 
-class AutoOptionsInterceptor(val routes: ArrayList<Route>): Interceptor {
+class AutoOptionsInterceptor(val routes: Set<Route>): Interceptor {
     override fun intercept(request: Request, response: Response): Boolean {
         var executeNext = false
         if (request.method == HttpMethod.OPTIONS) {

--- a/src/main/kotlin/org/wasabifx/wasabi/interceptors/CORSInterceptor.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/interceptors/CORSInterceptor.kt
@@ -10,7 +10,7 @@ import org.wasabifx.wasabi.routing.PatternAndVerbMatchingRouteLocator
 import org.wasabifx.wasabi.routing.Route
 import java.util.*
 
-class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORSEntry>): Interceptor {
+class CORSInterceptor(val routes: Set<Route>, val settings: ArrayList<CORSEntry>): Interceptor {
     override fun intercept(request: Request, response: Response): Boolean {
         val routeLocator = PatternAndVerbMatchingRouteLocator(routes)
 

--- a/src/main/kotlin/org/wasabifx/wasabi/routing/PatternAndVerbMatchingRouteLocator.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/routing/PatternAndVerbMatchingRouteLocator.kt
@@ -1,10 +1,9 @@
 package org.wasabifx.wasabi.routing
 
 import io.netty.handler.codec.http.HttpMethod
-import java.util.*
 
 
-class PatternAndVerbMatchingRouteLocator(val routes: List<Route>): RouteLocator {
+class PatternAndVerbMatchingRouteLocator(val routes: Set<Route>): RouteLocator {
 
 
     override fun compareRouteSegments(route1: Route, path: String): Boolean {
@@ -34,12 +33,12 @@ class PatternAndVerbMatchingRouteLocator(val routes: List<Route>): RouteLocator 
 
         val matchingVerbs = (matchingPaths.filter { it.method == method })
 
-        if (matchingVerbs.count() == 1) {
-            return matchingVerbs.firstOrNull()!!
+        if (matchingVerbs.count() > 0) {
+            val matchedRoute = if (matchingVerbs.count() == 1) matchingVerbs.first()
+                               else matchingVerbs.firstOrNull { it.path == path }
+            return matchedRoute ?: matchingVerbs.findMostWeightyBy(path)!!
         }
         val methods = arrayOf<HttpMethod>() // TODO: This needs to be filled
         throw InvalidMethodException(allowedMethods = methods)
     }
-
-
 }

--- a/src/main/kotlin/org/wasabifx/wasabi/routing/Route.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/routing/Route.kt
@@ -1,8 +1,26 @@
 package org.wasabifx.wasabi.routing
 
 import io.netty.handler.codec.http.HttpMethod
-import java.util.HashMap
+import java.util.*
 
 
-class Route(val path: String, val method: HttpMethod, val params: HashMap<String, String>, vararg val handler: RouteHandler.() -> Unit)
+class Route(val path: String, val method: HttpMethod, val params: HashMap<String, String>, vararg val handler: RouteHandler.() -> Unit) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other?.javaClass != javaClass) return false
+
+        other as Route
+
+        if (path != other.path) return false
+        if (method != other.method) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = path.hashCode()
+        result = 31 * result + method.hashCode()
+        return result
+    }
+}
 

--- a/src/main/kotlin/org/wasabifx/wasabi/routing/Routes.kt
+++ b/src/main/kotlin/org/wasabifx/wasabi/routing/Routes.kt
@@ -1,0 +1,50 @@
+package org.wasabifx.wasabi.routing
+
+import io.netty.handler.codec.http.HttpMethod
+
+/**
+ * @author Tradunsky V.V.
+ */
+fun Iterable<Route>.findMostWeightyBy(path: String): Route? {
+    val segments = path.split("/")
+    val routeWeights = mutableListOf<Pair<Double, Route>>()
+    for (route in this) {
+        val routeSegments = route.path.split("/")
+        if (routeSegments.size != segments.size) continue
+        var routeWeight = 0.0
+        segments.forEachIndexed { index, segment ->
+            if (segment.startsWith(':')) {
+                routeWeight += 0.5
+            } else if (segment.compareTo(routeSegments[index], ignoreCase = true) == 0) {
+                ++routeWeight
+            }
+        }
+        routeWeights.add(Pair(routeWeight, route))
+    }
+    return routeWeights.maxBy { it.first }?.second
+}
+
+fun Set<Route>.findSimilar(method: HttpMethod, path: String): Route? {
+    val segments = path.split("/")
+    for (route in this) {
+        val currentSegments = route.path.split("/")
+        if (segments.size != currentSegments.size || route.method != method) continue
+
+        if (areSegmentsEqual(segments, currentSegments)) return route
+    }
+    return null
+}
+
+private fun areSegmentsEqual(segments: List<String>, otherSegments: List<String>): Boolean {
+    var index = 0
+    for (segment in segments){
+        val anotherSegment = otherSegments[index]
+        if (segment.startsWith(":")) {
+            if (!anotherSegment.startsWith(":")) return false
+        }else if (anotherSegment.startsWith(":")) {
+            if (!segment.startsWith(":")) return false
+        } else if (segment.compareTo(anotherSegment, ignoreCase = true) != 0) return false
+        ++index
+    }
+    return true
+}

--- a/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
@@ -51,7 +51,7 @@ object TestServer {
         appServer.get("/first", { response.send("First")})
     }
 
-    val routes: ArrayList<Route>
+    val routes: Set<Route>
         get() = appServer.routes
 
     fun reset() {

--- a/test/main/kotlin/org/wasabifx/wasabi/test/RoutesSpecs.kt
+++ b/test/main/kotlin/org/wasabifx/wasabi/test/RoutesSpecs.kt
@@ -18,6 +18,15 @@ class RoutesSpecs {
         assertEquals(1, TestServer.appServer.routes.size)
     }
 
+    @spec fun finding_a_route_in_the_routing_table_should_return_route() {
+
+        TestServer.reset()
+        TestServer.appServer.get("/:id", { })
+
+        val routeLocator = PatternAndVerbMatchingRouteLocator(TestServer.routes)
+
+        assertNotNull(routeLocator.findRouteHandlers("/1", HttpMethod.GET))
+    }
 
     @spec fun finding_a_route_in_the_routing_table_by_matching_method_and_path_should_return_route() {
 
@@ -49,6 +58,39 @@ class RoutesSpecs {
 
     }
 
+    @spec fun finding_a_similar_route_in_the_routing_table_with_parameters_and_matching_method_should_return_route() {
+
+        TestServer.reset()
+        TestServer.appServer.get("/page/first", { response.send("first page")})
+        TestServer.appServer.get("/page/:id", { response.send("first id")})
+
+        val routeLocator = PatternAndVerbMatchingRouteLocator(TestServer.routes)
+
+        val route1 = routeLocator.findRouteHandlers("/page/first", HttpMethod.GET)
+        val route2 = routeLocator.findRouteHandlers("/page/smt", HttpMethod.GET)
+
+        assertNotNull(route1)
+        assertEquals("/page/first", route1.path)
+        assertNotNull(route2)
+        assertEquals("/page/:id", route2.path)
+    }
+
+    @spec fun finding_a_complex_route_in_the_routing_table_with_parameters_and_matching_method_should_return_route() {
+
+        TestServer.reset()
+        TestServer.appServer.get("/page/:id/view", { response.send("first page")})
+        TestServer.appServer.get("/page/:id/:format", { response.send("first id")})
+
+        val routeLocator = PatternAndVerbMatchingRouteLocator(TestServer.routes)
+
+        val route1 = routeLocator.findRouteHandlers("/page/one/view", HttpMethod.GET)
+        val route2 = routeLocator.findRouteHandlers("/page/one/json", HttpMethod.GET)
+
+        assertNotNull(route1)
+        assertEquals("/page/:id/view", route1.path)
+        assertNotNull(route2)
+        assertEquals("/page/:id/:format", route2.path)
+    }
 
     @spec fun finding_a_route_in_the_routing_table_when_path_found_but_not_method_throw_exception_method_not_permitted() {
 
@@ -74,6 +116,15 @@ class RoutesSpecs {
         val exception = assertFails { TestServer.appServer.get( "/", {}) }
 
         assertEquals("Path / with method GET already exists", exception.message)
+    }
+
+    @spec fun adding_a_second_route_in_the_routing_table_with_matching_path_param_and_method_should_throw_exception_indicating_route_exists() {
+
+        TestServer.reset()
+        TestServer.appServer.get( "/:param", {})
+        val exception = assertFails { TestServer.appServer.get( "/:id", {}) }
+
+        assertEquals("Path /:param with method GET already exists", exception.message)
     }
 }
 


### PR DESCRIPTION
Brief bug overview: 
get("/page/first")
get("/page/:id")

were not resolved at all.

Request processing should not lead to InvalidMethodException when there are more than one matched by http method and uri routes. 