### PR TITLE
session-management: fix NPE if no-cookie was set

### DIFF
--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
@@ -30,9 +30,9 @@ class SessionManagementInterceptor(val cookieKey: String = "_sessionID", session
         }
 
         // ensure a session is there
-        val session = request.session ?: Session(generateSessionID()).apply{
+        val session = request.session ?: Session(generateSessionID()).apply {
             storeSession(this)
-            request.session=this
+            request.session = this
         }
 
         // send the cookie

--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
@@ -15,23 +15,28 @@ class SessionManagementInterceptor(val cookieKey: String = "_sessionID", session
     }
 
     override fun intercept(request: Request, response: Response): Boolean {
+
+        // try loading the session
         if (request.cookies.containsKey(cookieKey)) {
             val cookie = request.cookies.get(cookieKey)
-
             if (cookie is Cookie) {
                 if (cookie.value() != "") {
                     request.session = loadSession(cookie.value())
                     request.session?.let {
                         it.extendSession()
                     }
-                } else {
-                    request.session = Session(generateSessionID())
-                    storeSession(request.session!!)
                 }
             }
         }
 
-        val tmpCookie = Cookie(cookieKey, request.session!!.id)
+        // ensure a session is there
+        val session = request.session ?: Session(generateSessionID()).apply{
+            storeSession(this)
+            request.session=this
+        }
+
+        // send the cookie
+        val tmpCookie = Cookie(cookieKey, session.id)
         tmpCookie.setDomain(request.host)
         tmpCookie.isSecure = request.isSecure
         tmpCookie.setPath(request.path)
@@ -41,7 +46,6 @@ class SessionManagementInterceptor(val cookieKey: String = "_sessionID", session
         return true
     }
 }
-
 
 fun AppServer.enableSessionSupport() {
     intercept(SessionManagementInterceptor())


### PR DESCRIPTION
If no cookie was set (i.e. first request from browser), the request.session is null.
This would result in a NullPointerException due to usage of "!!" operator.

Solution: Ensure that a session exists by creating it via "?:" operator.