### PR TITLE
Hotfix session

### DIFF
--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/interceptors/SessionManagementInterceptor.kt
@@ -34,7 +34,7 @@ class SessionManagementInterceptor(val cookieKey: String = "_sessionID", session
         val tmpCookie = Cookie(cookieKey, request.session!!.id)
         tmpCookie.setDomain(request.host)
         tmpCookie.isSecure = request.isSecure
-        tmpCookie.setPath(request.path)
+        tmpCookie.setPath("/")
 
         response.setCookie(tmpCookie)
 

--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Response.kt
@@ -1,6 +1,7 @@
 package org.wasabifx.wasabi.protocol.http
 
 import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
@@ -24,7 +25,7 @@ class Response() {
     var sendBuffer: Any? = null
         private set
     var overrideContentNegotiation: Boolean = false
-    val cookies : HashMap<String, Cookie> = HashMap<String, Cookie>()
+    val cookies : HashMap<String, Cookie> = HashMap()
     var requestedContentTypes: ArrayList<String> = arrayListOf()
     var negotiatedMediaType: String = ""
     var connection: String = "close"
@@ -142,8 +143,9 @@ class Response() {
             headerList.add(newHeaderItem("Last-Modified", convertToDateFormat(it)))
         }
 
-        for (cookie in cookies) {
-            headerList.add(newHeaderItem("Set-Cookie", cookie.toString()))
+        for ((cookieName, cookie) in cookies) {
+            val cookieString = ServerCookieEncoder.STRICT.encode(cookie)
+            headerList.add(newHeaderItem("Set-Cookie", cookieString))
         }
 
         return headerList
@@ -154,7 +156,7 @@ class Response() {
     }
 
     fun setCookie(cookie: Cookie) {
-        cookies[cookie.name()] = cookie
+        cookies.put(cookie.name(), cookie)
     }
 
     private fun getSupportedHeaderNames() : List<String> {

--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/storage/InMemorySessionStorage.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/storage/InMemorySessionStorage.kt
@@ -12,6 +12,8 @@ class InMemorySessionStorage: SessionStorage {
         inMemorySession.put(session.id, session)
     }
     override fun loadSession(sessionID: String): Session {
+        inMemorySession.putIfAbsent(sessionID, Session(sessionID))
+
         return inMemorySession.get(sessionID)!!
     }
 }

--- a/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/InMemorySessionStorageSpec.kt
+++ b/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/InMemorySessionStorageSpec.kt
@@ -1,0 +1,17 @@
+package org.wasabifx.wasabi.test
+
+import org.wasabifx.wasabi.protocol.http.Session
+import org.wasabifx.wasabi.storage.InMemorySessionStorage
+import kotlin.test.assertTrue
+import org.junit.Test as spec
+
+class InMemorySessionStorageSpec {
+
+    @spec fun loading_session_with_non_existing_session_id_should_return_new_session() {
+        val inMemorySessionStorage = InMemorySessionStorage()
+
+        val session = inMemorySessionStorage.loadSession("this-id-does-not-exist-for-sure")
+        assertTrue(session is Session)
+    }
+
+}

--- a/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/ResponseSpecs.kt
+++ b/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/ResponseSpecs.kt
@@ -1,0 +1,31 @@
+package org.wasabifx.wasabi.test
+
+import org.wasabifx.wasabi.protocol.http.Cookie
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test as spec
+
+class ResponseSpecs: TestServerContext() {
+
+    @spec fun cookies_must_be_encoded_with_ServerCookieEncoder() {
+        TestServer.reset()
+        TestServer.appServer.get("/test", {
+            val cookie = Cookie("testing", "lipsum")
+            cookie.setPath("/test")
+            cookie.setDomain("localhost")
+            cookie.isSecure = true
+            cookie.isHttpOnly = true
+            response.setCookie(cookie)
+            response.send("test", "plain/text")
+        })
+
+        val response = TestClient(TestServer.appServer).sendSimpleRequest("/test", "GET")
+        val cookieHeaders = response.headers.filter { it.name == "Set-Cookie" }
+        assertTrue(cookieHeaders.count() > 0)
+
+        val cookieString = cookieHeaders.first().value
+
+        assertEquals("testing=lipsum; Path=/test; Domain=localhost; Secure; HTTPOnly", cookieString)
+    }
+
+}


### PR DESCRIPTION
Session cookie now will be with path "/" for all routes;
Response class was returning incorrect Set-Cookie header , so started using Netty's ServerCookieEncoder;
InMemorySessionStorage was crashing if you request to load session with non-existing session id - it should create a new instance of session instead of crashing.