### PR TITLE
Add support for specifying hostname alongside port via AppConfiguration

### DIFF
--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/app/AppConfiguration.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/app/AppConfiguration.kt
@@ -11,7 +11,8 @@ var configuration : AppConfiguration? = null
 
 data class AppConfiguration(
         var port: Int = 3000,
-        var welcomeMessage: String = "Server starting on port $port",
+        var hostname: String? = null,
+        var welcomeMessage: String = "Server starting ${hostname?.let { "at $hostname:$port"  } ?: "on port $port"}",
         var enableContentNegotiation: Boolean = true,
         var enableLogging: Boolean = true,
         var enableAutoOptions: Boolean = false,

--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpServer.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/HttpServer.kt
@@ -88,7 +88,13 @@ class HttpServer(private val appServer: AppServer) {
     }
 
     fun start(wait: Boolean = true) {
-        val channel = bootstrap.bind(appServer.configuration.port)?.sync()?.channel()
+        val configuration = appServer.configuration
+
+        val channelFuture = configuration.hostname?.let {
+          bootstrap.bind(it, configuration.port)
+        } ?: bootstrap.bind(configuration.port)
+
+        val channel = channelFuture?.sync()?.channel()
 
         if (wait) {
             channel?.closeFuture()?.sync()

--- a/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Request.kt
+++ b/wasabi-core/src/main/kotlin/org/wasabifx/wasabi/protocol/http/Request.kt
@@ -9,181 +9,188 @@ import io.netty.handler.codec.http.multipart.InterfaceHttpData.HttpDataType
 import io.netty.handler.codec.http2.Http2Headers
 import org.slf4j.LoggerFactory
 import org.wasabifx.wasabi.app.configuration
+import java.lang.Exception
 import java.net.InetSocketAddress
 import java.util.*
 
 class Request() {
 
 
-    constructor(httpRequest: HttpRequest, address: InetSocketAddress) : this() {
-        this.httpRequest = httpRequest
-        this.rawHeaders = httpRequest.headers().associate({it.key.toLowerCase() to it.value})
-        this.uri = httpRequest.uri!!
-        this.method = httpRequest.method!!
-        this.document = uri.drop(uri.lastIndexOf("/") + 1)
-        this.path = uri.split('?')[0]
-        this.scheme = if (configuration!!.sslEnabled) "https" else "http"
-        this.remoteAddress = address
-    }
+   constructor(httpRequest: HttpRequest,
+               address: InetSocketAddress) : this() {
+      this.httpRequest = httpRequest
+      this.rawHeaders = httpRequest.headers().associate({ it.key.toLowerCase() to it.value })
+      this.uri = httpRequest.uri!!
+      this.method = httpRequest.method!!
+      this.document = uri.drop(uri.lastIndexOf("/") + 1)
+      this.path = uri.split('?')[0]
+      this.scheme = if (configuration!!.sslEnabled) "https" else "http"
+      this.remoteAddress = address
+   }
 
-    constructor(http2Headers: Http2Headers?, address: InetSocketAddress) : this() {
-        this.http2Headers = http2Headers!!
-        this.rawHeaders = http2Headers.associate({it.key.toString().toLowerCase() to it.value.toString()})
-        this.uri = http2Headers.path().toString()
-        this.method = HttpMethod(http2Headers.method().toString())
-        this.document = uri.drop(uri.lastIndexOf("/") + 1)
-        this.path = uri
-        this.scheme = getHeader("scheme")
-        this.remoteAddress = address
-    }
+   constructor(http2Headers: Http2Headers?,
+               address: InetSocketAddress) : this() {
+      this.http2Headers = http2Headers!!
+      this.rawHeaders = http2Headers.associate({ it.key.toString().toLowerCase() to it.value.toString() })
+      this.uri = http2Headers.path().toString()
+      this.method = HttpMethod(http2Headers.method().toString())
+      this.document = uri.drop(uri.lastIndexOf("/") + 1)
+      this.path = uri
+      this.scheme = getHeader("scheme")
+      this.remoteAddress = address
+   }
 
-    lateinit var httpRequest : HttpRequest
+   lateinit var httpRequest: HttpRequest
 
-    lateinit var http2Headers : Http2Headers
+   lateinit var http2Headers: Http2Headers
 
-    lateinit var uri: String
-    lateinit var method: HttpMethod
-    lateinit var rawHeaders: Map<String,String>
-    lateinit var document: String
-    lateinit var path: String
-    lateinit var scheme: String
-    lateinit var remoteAddress: InetSocketAddress
-    lateinit var body: ByteArray
+   lateinit var uri: String
+   lateinit var method: HttpMethod
+   lateinit var rawHeaders: Map<String, String>
+   lateinit var document: String
+   lateinit var path: String
+   lateinit var scheme: String
+   lateinit var remoteAddress: InetSocketAddress
+   lateinit var body: ByteArray
 
-    val host: String by lazy {
-        getHeader("Host").takeWhile { it != ':' }
-    }
-    val protocol: String by lazy {
-        this.scheme
-    }
-    val isSecure: Boolean by lazy {
-        protocol.compareTo("https", ignoreCase = true) == 0
-    }
-    val urlPort: String by lazy {
-        getHeader("Host").dropWhile { it != ':' }.drop(1)
-    }
-    val port: Int by lazy {
-        if (urlPort != "") urlPort.toInt() else 80
-    }
-    val connection: String by lazy {
-        getHeader("Connection")
-    }
-    val cacheControl: String by lazy {
-        getHeader("Cache-Control")
-    }
-    val userAgent: String by lazy {
-        getHeader("User-Agent")
-    }
-    val accept: SortedMap<String, Int> by lazy {
-        parseAcceptHeader("Accept")
-    }
-    val acceptEncoding: SortedMap<String, Int> by lazy {
-        parseAcceptHeader("Accept-Encoding")
-    }
-    val acceptLanguage: SortedMap<String, Int> by lazy {
-        parseAcceptHeader("Accept-Language")
-    }
-    val acceptCharset: SortedMap<String, Int> by lazy {
-        parseAcceptHeader("Accept-Charset")
-    }
-    val ifNoneMatch: String by lazy {
-        getHeader("If-None-Match")
-    }
-    val queryParams: HashMap<String, String> by lazy {
-        parseQueryParams()
-    }
-    val routeParams: HashMap<String, String> = HashMap()
-    val bodyParams: HashMap<String, Any> = HashMap()
-    val cookies: HashMap<String, Cookie> by lazy {
-        parseCookies()
-    }
-    val contentType: String by lazy {
-        getHeader("Content-Type")
-    }
-    val chunked: Boolean by lazy {
-        getHeader("Transfer-Encoding").compareTo("chunked", ignoreCase = true) == 0
-    }
-    val authorization: String by lazy {
-        getHeader("Authorization")
-    }
+   val host: String by lazy {
+      getHeader("Host").takeWhile { it != ':' }
+   }
+   val protocol: String by lazy {
+      this.scheme
+   }
+   val isSecure: Boolean by lazy {
+      protocol.compareTo("https", ignoreCase = true) == 0
+   }
+   val urlPort: String by lazy {
+      getHeader("Host").dropWhile { it != ':' }.drop(1)
+   }
+   val port: Int by lazy {
+      if (urlPort != "") urlPort.toInt() else 80
+   }
+   val connection: String by lazy {
+      getHeader("Connection")
+   }
+   val cacheControl: String by lazy {
+      getHeader("Cache-Control")
+   }
+   val userAgent: String by lazy {
+      getHeader("User-Agent")
+   }
+   val accept: SortedMap<String, Int> by lazy {
+      parseAcceptHeader("Accept")
+   }
+   val acceptEncoding: SortedMap<String, Int> by lazy {
+      parseAcceptHeader("Accept-Encoding")
+   }
+   val acceptLanguage: SortedMap<String, Int> by lazy {
+      parseAcceptHeader("Accept-Language")
+   }
+   val acceptCharset: SortedMap<String, Int> by lazy {
+      parseAcceptHeader("Accept-Charset")
+   }
+   val ifNoneMatch: String by lazy {
+      getHeader("If-None-Match")
+   }
+   val queryParams: HashMap<String, String> by lazy {
+      parseQueryParams()
+   }
+   val routeParams: HashMap<String, String> = HashMap()
+   val bodyParams: HashMap<String, Any> = HashMap()
+   val cookies: HashMap<String, Cookie> by lazy {
+      parseCookies()
+   }
+   val contentType: String by lazy {
+      getHeader("Content-Type")
+   }
+   val chunked: Boolean by lazy {
+      getHeader("Transfer-Encoding").compareTo("chunked", ignoreCase = true) == 0
+   }
+   val authorization: String by lazy {
+      getHeader("Authorization")
+   }
 
 
-    var session: Session? = null
+   var session: Session? = null
 
-    // TODO add charset and parse method to split charset from contentType if it exists.
+   // TODO add charset and parse method to split charset from contentType if it exists.
 
-    private fun parseAcceptHeader(header: String): SortedMap<String, Int> {
+   private fun parseAcceptHeader(header: String): SortedMap<String, Int> {
 
-        val parsed = hashMapOf<String, Int>()
-        val entries = getHeader(header).split(',')
-        for (entry in entries) {
-            val parts = entry.split(';')
-            val mediaType = parts[0]
-            var weight = 1
-            if (parts.size == 2) {
-                val float = parts[1].trim().drop(2).toFloat() * 10
-                weight = float.toInt()
+      val parsed = hashMapOf<String, Int>()
+      val entries = getHeader(header).split(',')
+      for (entry in entries) {
+         val parts = entry.split(';')
+         val mediaType = parts[0]
+         var weight = 1
+         if (parts.size == 2) {
+            val float = try {
+               parts[1].trim().drop(2).toFloat() * 10
+            } catch (exception: Exception) {
+               0f
             }
-            parsed.put(mediaType, weight)
-        }
-        return parsed.toSortedMap<String, Int>()
-    }
+            weight = float.toInt()
+         }
+         parsed.put(mediaType, weight)
+      }
+      return parsed.toSortedMap<String, Int>()
+   }
 
-    private fun getHeader(header: String) = this.rawHeaders[header.toLowerCase()] ?: ""
+   private fun getHeader(header: String) = this.rawHeaders[header.toLowerCase()] ?: ""
 
-    private fun parseQueryParams(): HashMap<String, String> {
-        val queryParamsList = hashMapOf<String, String>()
-        // TODO fix
-        val urlParams = uri.split('?')
-        if (urlParams.size == 2) {
-            val queryNameValuePair = urlParams[1].split("&")
-            for (entry in queryNameValuePair) {
-                val nameValuePair = entry.split('=')
-                if (nameValuePair.size == 2) {
-                    queryParamsList[nameValuePair[0]] = nameValuePair[1]
-                } else {
-                    queryParamsList[nameValuePair[0]] = ""
-                }
+   private fun parseQueryParams(): HashMap<String, String> {
+      val queryParamsList = hashMapOf<String, String>()
+      // TODO fix
+      val urlParams = uri.split('?')
+      if (urlParams.size == 2) {
+         val queryNameValuePair = urlParams[1].split("&")
+         for (entry in queryNameValuePair) {
+            val nameValuePair = entry.split('=')
+            if (nameValuePair.size == 2) {
+               queryParamsList[nameValuePair[0]] = nameValuePair[1]
+            } else {
+               queryParamsList[nameValuePair[0]] = ""
             }
-        }
-        return queryParamsList
-    }
+         }
+      }
+      return queryParamsList
+   }
 
-    private fun parseCookies(): HashMap<String, Cookie> {
-        val cookieHeader = getHeader("Cookie")
-        val cookieSet = ServerCookieDecoder.STRICT.decode(cookieHeader)
-        val cookieList = hashMapOf<String, Cookie>()
-        cookieSet?.iterator()?.forEach { cookie ->
-            val tmpCookie = Cookie(cookie.name().toString(), cookie.value().toString())
+   private fun parseCookies(): HashMap<String, Cookie> {
+      val cookieHeader = getHeader("Cookie")
+      val cookieSet = ServerCookieDecoder.STRICT.decode(cookieHeader)
+      val cookieList = hashMapOf<String, Cookie>()
+      cookieSet?.iterator()?.forEach { cookie ->
+         val tmpCookie = Cookie(cookie.name().toString(), cookie.value().toString())
 
-            if (cookie.path() != null) {
-                tmpCookie.setPath(cookie.path())
-            }
+         if (cookie.path() != null) {
+            tmpCookie.setPath(cookie.path())
+         }
 
-            if (cookie.domain() != null) {
-                tmpCookie.setDomain(cookie.domain())
-            }
+         if (cookie.domain() != null) {
+            tmpCookie.setDomain(cookie.domain())
+         }
 
-            tmpCookie.isSecure = cookie.isSecure
-            cookieList[cookie.name().toString()] = tmpCookie
-        }
-        return cookieList
-    }
+         tmpCookie.isSecure = cookie.isSecure
+         cookieList[cookie.name().toString()] = tmpCookie
+      }
+      return cookieList
+   }
 
 
-    fun parseBodyParams(httpDataList: MutableList<InterfaceHttpData>) {
-        for (entry in httpDataList) {
-            addBodyParam(entry)
-        }
-    }
+   fun parseBodyParams(httpDataList: MutableList<InterfaceHttpData>) {
+      for (entry in httpDataList) {
+         addBodyParam(entry)
+      }
+   }
 
-    fun addBodyParam(httpData: InterfaceHttpData) {
-        // TODO: Add support for other types of attributes (namely file)
-        if (httpData.httpDataType == HttpDataType.Attribute) {
-            val attribute = httpData as Attribute
-            bodyParams[attribute.name.toString()] = attribute.value.toString()
-        }
-    }
+   fun addBodyParam(httpData: InterfaceHttpData) {
+      // TODO: Add support for other types of attributes (namely file)
+      if (httpData.httpDataType == HttpDataType.Attribute) {
+         val attribute = httpData as Attribute
+         bodyParams[attribute.name.toString()] = attribute.value.toString()
+      }
+   }
 }
 
 

--- a/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/ConfigSpecs.kt
+++ b/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/ConfigSpecs.kt
@@ -14,6 +14,8 @@ class ConfigSpecs {
         val appServer = AppServer()
 
         assertEquals(3000, appServer.configuration.port)
+        assertEquals(null, appServer.configuration.hostname)
+
         assertEquals("Server starting on port 3000", appServer.configuration.welcomeMessage)
         assertEquals(true, appServer.configuration.enableLogging)
     }
@@ -32,6 +34,15 @@ class ConfigSpecs {
         assertEquals(false, appServer.configuration.enableLogging)
     }
 
+    @spec fun specifying_hostname_changes_default_welcome_message() {
+        val appServer = AppServer(
+                AppConfiguration(
+                        port = 5000,
+                        hostname = "127.0.0.1"))
 
+        assertEquals(5000, appServer.configuration.port)
+        assertEquals("127.0.0.1", appServer.configuration.hostname)
 
+        assertEquals("Server starting at 127.0.0.1:5000", appServer.configuration.welcomeMessage)
+    }
 }

--- a/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
+++ b/wasabi-core/src/test/main/kotlin/org/wasabifx/wasabi/test/Helpers.kt
@@ -32,7 +32,10 @@ open class TestServerContext {
 object TestServer {
 
     val definedPort: Int = Random().nextInt(30000) + 5000
-    var appServer: AppServer = AppServer(AppConfiguration(definedPort))
+    var appServer: AppServer = AppServer(AppConfiguration(
+      port = definedPort,
+      hostname = "127.0.0.1"
+    ))
 
     fun start() {
         try {
@@ -137,5 +140,3 @@ fun postForm(url: String, headers: HashMap<String, String>, fields: ArrayList<Ba
 }
 
 data class HttpClientResponse(val headers: Array<Header>, val body: String?, val statusCode: Int, val statusDescription: String)
-
-


### PR DESCRIPTION
I am building a web server that supports a local browser-based app. I
do not want that web server to be accessible to other devices on the
network (e.g. other people at a coffeeshop). So, as a start, I’d like
to specify the hostname that the wasabi HTTPServer binds to be
127.0.0.1 instead of the default wildcard (0.0.0.0).

I am leaving the default hostname as null, which uses the previous
behavior. I believe this is consistent with NodeJS’s defaults, so I
don’t have motivation to change the defaults (athough, it would be more
conservative to not assume the user wants their in-development web
server to be accessible to other devices on the network).

I did however change the AppServer used during tests to use 127.0.0.1
instead of 0.0.0.0. Since tests are run locally, this change didn’t
require any other changes. Hypothetically, this would prevent tests
randomly being influenced by some unexpected traffic on your network
(again e.g., someone port scanning at a coffee shop).

Unfortunately, I could not think of a way to test the negative - that
servers are inaccessible from outside of localhost. I did test this
manually in my real-world app, though.